### PR TITLE
拉黑知乎 HTTPDNS 使用的 IPv4 & IPv6 & 修复 Quantumult X 无法识别生成的 IP-CIDR6 规则的问题

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -174,6 +174,8 @@ def generate_quantumultx(config):
     rules = ''
     for rule in config['config']['rules']:
         rule = rule.strip()
+        if "IP-CIDR6" in rule:
+            rule = rule.replace('IP-CIDR6','IP6-CIDR')
         if len(seprate_comma(rule)) == 2:
             rules += rule + ',IP\n'
         else:

--- a/rules.yaml
+++ b/rules.yaml
@@ -71,7 +71,7 @@ config:
     # 有报告iOS端使用规则后仍然泄露真实IP属地
     # https://github.com/lwd-temp/anti-ip-attribution/issues/24
     - IP-CIDR,118.89.204.198/23,REJECT # 知乎 HTTPDNS (IPv4)
-    # - IP-CIDR6,2402:4e00:1200:ed00:0:9089:6dac:96b6/40,REJECT # 知乎 HTTPDNS (IPv6)
+    - IP-CIDR6,2402:4e00:1200:ed00:0:9089:6dac:96b6/40,REJECT # 知乎 HTTPDNS (IPv6)
     # ======= 国家反诈中心 ======= #
     # 国家反诈中心App
     # - DOMAIN-SUFFIX,gjfzpt.cn,REJECT # 国家反诈中心域名，全部阻断

--- a/rules.yaml
+++ b/rules.yaml
@@ -70,8 +70,8 @@ config:
     - IP-CIDR,103.41.167.0/24 # 网友提供知乎IP定位接口
     # 有报告iOS端使用规则后仍然泄露真实IP属地
     # https://github.com/lwd-temp/anti-ip-attribution/issues/24
-    # - IP-CIDR,118.89.204.198,REJECT
-    # - IP-CIDR6,[2402:4e00:1200:ed00:0:9089:6dac:96b6],REJECT
+    - IP-CIDR,118.89.204.198/23,REJECT # 知乎 HTTPDNS (IPv4)
+    # - IP-CIDR6,2402:4e00:1200:ed00:0:9089:6dac:96b6/40,REJECT # 知乎 HTTPDNS (IPv6)
     # ======= 国家反诈中心 ======= #
     # 国家反诈中心App
     # - DOMAIN-SUFFIX,gjfzpt.cn,REJECT # 国家反诈中心域名，全部阻断


### PR DESCRIPTION
Issue: #24 
目前在 Quantumult X 测试将 118.89.204.198/23 添加 REJECT 规则后可以阻止知乎 iOS 端获取真实 IP 属地。