### PR TITLE
森空岛

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -283,3 +283,5 @@ config:
     # 测试
     - DOMAIN,y.qq.com,DIRECT # 图片资源，直连
     - DOMAIN-SUFFIX,y.qq.com # u*.y.qq.com
+    # ======= 森空岛 ====== #
+    - DOMAIN,zonai.skland.com


### PR DESCRIPTION
通过抓包可得`zonai.skland.com`为其获取用户信息的api域名