### PR TITLE
fix: update Weibo domain list, see details in #5

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -68,6 +68,9 @@ config:
     - DOMAIN-SUFFIX,weibo.cn
     - DOMAIN-SUFFIX,weibo.com
     - DOMAIN-SUFFIX,weibocdn.com
+    - DOMAIN-SUFFIX,wbimg.cn
+    - DOMAIN-SUFFIX,wbimg.com
+    - DOMAIN-SUFFIX,sinaimg.cn
     - DOMAIN-KEYWORD,weibo
     # ======= 百度贴吧 ======= #
     # 百度贴吧


### PR DESCRIPTION
已测试 ios 版微博可以正确分流，不暴露 ip 归属地
ios 微博版本号：14.13.2